### PR TITLE
fix: remove incorrect maxSdkVersion from READ_MEDIA_IMAGES

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,5 +7,5 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
  
     <!-- eles -->  
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33" android:maxSdkVersion="33" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33"  />
 </manifest>


### PR DESCRIPTION
## Summary
Removed incorrect `maxSdkVersion` from `READ_MEDIA_IMAGES` in AndroidManifest.xml.

## Why
- `READ_MEDIA_IMAGES` is supported only on API 33+.
- `maxSdkVersion` should not be used here.
- The previous AndroidManifest setup could cause unexpected behavior in existing projects that use the `READ_MEDIA_IMAGES` permission.
  
## Testing
- Tested on Android 13 and 14 devices.
- Works without permission errors.