### PR TITLE
fix: Remove unnecessary permission requests from android platform

### DIFF
--- a/android/src/main/java/com/captureprotection/CaptureProtectionModule.kt
+++ b/android/src/main/java/com/captureprotection/CaptureProtectionModule.kt
@@ -64,7 +64,6 @@ class CaptureProtectionModule(private val reactContext: ReactApplicationContext)
         val currentActivity = ActivityUtils.getReactCurrentActivity(reactContext)
         currentActivity!!.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         Response.sendEvent(reactContext, Constants.LISTENER_EVENT_NAME, StatusCode.UNKNOWN.ordinal)
-        super.addScreenCaptureListener()
         promise.resolve(true)
       } catch (e: Exception) {
         promise.reject("preventScreenshot", e)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -122,7 +122,6 @@ const allowScreenRecord = async (removeListener = false): Promise<void> => {
  */
 const preventScreenRecord = async (isImmediate = false): Promise<void> => {
   if (Platform.OS === 'android') {
-    await requestPermission();
     return await CaptureProtectionModule?.preventScreenshot?.();
   }
   if (Platform.OS === 'ios') {
@@ -153,7 +152,6 @@ const allowScreenshot = async (removeListener = false): Promise<void> => {
  */
 const preventScreenshot = async (): Promise<void> => {
   if (Platform.OS === 'android') {
-    await requestPermission();
     return await CaptureProtectionModule?.preventScreenshot?.();
   }
   if (Platform.OS === 'ios') {


### PR DESCRIPTION
The android platform will have a system alert after disabling the screenshot, so you don't need to listen to the screenshot event anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the screen capture and recording protection on Android. The prevention process now activates more directly by removing extra steps, such as redundant permissions and listener registration, resulting in a more immediate and consistent protection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->