### PR TITLE
fix: image not set

### DIFF
--- a/ios/CaptureProtection.m
+++ b/ios/CaptureProtection.m
@@ -18,6 +18,8 @@ RCT_EXTERN_METHOD(preventScreenRecordWithText:(NSString *) text
                   backgroundColor: (NSString *) backgroundColor
                   resolver:(RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock) reject)
 RCT_EXTERN_METHOD(preventScreenRecordWithImage:(NSDictionary*) image
+                  backgroundColor: (NSString *) backgroundColor
+                  contentMode: (double) contentMode
                   resolver:(RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock) reject)
 
 // App Switcher
@@ -29,6 +31,8 @@ RCT_EXTERN_METHOD(preventAppSwitcherWithText:(NSString *)text
                   backgroundColor: (NSString *)backgroundColor
                   resolver:(RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock) reject)
 RCT_EXTERN_METHOD(preventAppSwitcherWithImage:(NSDictionary*) image
+                  backgroundColor: (NSString *) backgroundColor
+                  contentMode: (double) contentMode
                   resolver:(RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock) reject)
 
 // Etc

--- a/ios/CaptureProtection/CaptureProtection.swift
+++ b/ios/CaptureProtection/CaptureProtection.swift
@@ -106,6 +106,8 @@ class CaptureProtection: RCTEventEmitter {
     }
     
     @objc func preventScreenRecordWithImage(_ image: NSDictionary,
+                                            backgroundColor: String,
+                                            contentMode: Double,
                                             resolver: @escaping RCTPromiseResolveBlock,
                                             rejecter: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async { [self] in
@@ -114,6 +116,9 @@ class CaptureProtection: RCTEventEmitter {
             
             do {
                 CaptureProtection.protectionViewConfig.screenRecord.type = Constants.CaptureProtectionType.IMAGE
+                CaptureProtection.protectionViewConfig.screenRecord.backgroundColor = backgroundColor
+               
+                CaptureProtection.protectionViewConfig.screenRecord.contentMode = UIView.ContentMode(rawValue: Int(contentMode)) ?? .scaleAspectFit
                 if let screenImage = RCTConvert.uiImage(image) {
                     CaptureProtection.protectionViewConfig.screenRecord.image = screenImage
                     resolver(nil)
@@ -156,6 +161,8 @@ class CaptureProtection: RCTEventEmitter {
     }
     
     @objc func preventAppSwitcherWithImage(_ image: NSDictionary,
+                                           backgroundColor: String,
+                                           contentMode: Double,
                                            resolver: @escaping RCTPromiseResolveBlock,
                                            rejecter: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async { [self] in
@@ -164,6 +171,8 @@ class CaptureProtection: RCTEventEmitter {
 
             do {
                 CaptureProtection.protectionViewConfig.appSwitcher.type = Constants.CaptureProtectionType.IMAGE
+                CaptureProtection.protectionViewConfig.appSwitcher.backgroundColor = backgroundColor
+                CaptureProtection.protectionViewConfig.appSwitcher.contentMode = UIView.ContentMode(rawValue: Int(contentMode)) ?? .scaleAspectFit
                 if let screenImage = RCTConvert.uiImage(image) {
                     CaptureProtection.protectionViewConfig.appSwitcher.image = screenImage
                     resolver(nil)
@@ -377,7 +386,9 @@ class CaptureProtection: RCTEventEmitter {
                 } else if config.type == Constants.CaptureProtectionType.IMAGE {
                     CaptureProtection.protectionViewConfig.screenRecord.viewController = UIViewUtils.imageView(
                         tag: Constants.TAG_RECORD_PROTECTION_SCREEN,
-                        image: config.image!)
+                        image: config.image!,
+                        backgroundColor: config.backgroundColor,
+                        contentMode: config.contentMode)
                 } else {
                     CaptureProtection.protectionViewConfig.screenRecord.viewController = UIViewUtils.view(
                         tag: Constants.TAG_RECORD_PROTECTION_SCREEN,
@@ -410,7 +421,7 @@ class CaptureProtection: RCTEventEmitter {
                         if config.type == Constants.CaptureProtectionType.TEXT {
                             CaptureProtection.protectionViewConfig.appSwitcher.viewController = UIViewUtils.textView(tag: Constants.TAG_APP_SWITCHER_PROTECTION, text: config.text!, textColor: config.textColor, backgroundColor: config.backgroundColor)
                         } else if config.type == Constants.CaptureProtectionType.IMAGE {
-                            CaptureProtection.protectionViewConfig.appSwitcher.viewController = UIViewUtils.imageView(tag: Constants.TAG_APP_SWITCHER_PROTECTION, image: config.image!)
+                            CaptureProtection.protectionViewConfig.appSwitcher.viewController = UIViewUtils.imageView(tag: Constants.TAG_APP_SWITCHER_PROTECTION, image: config.image!, backgroundColor: config.backgroundColor, contentMode: config.contentMode)
                         } else {
                             CaptureProtection.protectionViewConfig.appSwitcher.viewController = UIViewUtils.view(
                                 tag: Constants.TAG_APP_SWITCHER_PROTECTION,

--- a/ios/CaptureProtection/Constants/Config.swift
+++ b/ios/CaptureProtection/Constants/Config.swift
@@ -37,6 +37,7 @@ public struct ProtectorViewOption {
     public var backgroundColor: String = "#FFFFFF"
     public var image: UIImage?
     public var type: Constants.CaptureProtectionType = Constants.CaptureProtectionType.NONE
+    public var contentMode: UIView.ContentMode = .scaleAspectFit
 }
 
 public class ProtectionViewConfig {

--- a/ios/CaptureProtection/Utils/UIViewUtils.swift
+++ b/ios/CaptureProtection/Utils/UIViewUtils.swift
@@ -9,7 +9,7 @@ import UIKit
 import Foundation
 
 public class UIViewUtils {
-    public static func imageView(tag: Int, image: UIImage) -> UIViewController  {
+    public static func imageView(tag: Int, image: UIImage, backgroundColor: String, contentMode: UIView.ContentMode) -> UIViewController  {
         guard let window = UIApplication.shared.delegate?.window ?? nil else { return UIViewController() }
         
         let viewController = UIViewController()
@@ -18,10 +18,10 @@ public class UIViewUtils {
         let imageView = UIImageView(image: image)
         imageView.frame = window.frame
         imageView.clipsToBounds = true
-        imageView.contentMode = .scaleAspectFit
+        imageView.contentMode = contentMode
         
         viewController.view.addSubview(imageView)
-        viewController.view.backgroundColor = .white
+        viewController.view.backgroundColor = TextUtils.colorFromHexString(hexString: backgroundColor, defaultColor: .white)
         
         return viewController
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-capture-protection",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "🛡️ A React Native library to prevent and detect for screen capture, screenshots and app switcher for enhanced security. Fully compatible with both Expo and CLI.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,4 +1,9 @@
-import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
+import {
+  Image,
+  NativeEventEmitter,
+  NativeModules,
+  Platform,
+} from 'react-native';
 import {
   CaptureProtectionAndroidNativeModules,
   CaptureProtectionFunction,
@@ -74,7 +79,9 @@ const prevent: CaptureProtectionFunction['prevent'] = async (option) => {
       } else if (typeof appSwitcher === 'object') {
         if ('image' in appSwitcher) {
           await CaptureProtectionIOSModule?.preventAppSwitcherWithImage?.(
-            appSwitcher.image
+            Image.resolveAssetSource(appSwitcher.image as unknown as number),
+            appSwitcher?.backgroundColor,
+            appSwitcher?.contentMode
           );
         } else {
           await CaptureProtectionIOSModule?.preventAppSwitcherWithText?.(
@@ -92,7 +99,9 @@ const prevent: CaptureProtectionFunction['prevent'] = async (option) => {
       } else if (typeof record === 'object') {
         if ('image' in record) {
           await CaptureProtectionIOSModule?.preventScreenRecordWithImage?.(
-            record.image
+            Image.resolveAssetSource(record.image as unknown as number),
+            record?.backgroundColor,
+            record?.contentMode
           );
         } else {
           await CaptureProtectionIOSModule?.preventScreenRecordWithText?.(

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,4 @@
-import { EmitterSubscription } from 'react-native';
+import { EmitterSubscription, ImageResolvedAssetSource } from 'react-native';
 
 export enum CaptureEventType {
   NONE,
@@ -28,6 +28,8 @@ export type IOSProtectionCustomScreenOption = {
 export type IOSProtectionScreenOption =
   | {
       image: NodeRequire;
+      backgroundColor?: `#${string}`;
+      contentMode?: ContentMode;
     }
   | IOSProtectionCustomScreenOption;
 
@@ -45,6 +47,21 @@ export type AllowOption = {
 
 export type CaptureEventCallback = (eventType: CaptureEventType) => void;
 
+export enum ContentMode {
+  scaleToFill = 0,
+  scaleAspectFit = 1,
+  scaleAspectFill = 2,
+  redraw = 3,
+  center = 4,
+  top = 5,
+  bottom = 6,
+  left = 7,
+  right = 8,
+  topLeft = 9,
+  topRight = 10,
+  bottomLeft = 11,
+  bottomRight = 12,
+}
 export interface CaptureProtectionIOSNativeModules {
   allowScreenshot: () => Promise<void>;
   preventScreenshot: () => Promise<void>;
@@ -55,7 +72,11 @@ export interface CaptureProtectionIOSNativeModules {
     textColor?: `#${string}`,
     backgroundColor?: `#${string}`
   ) => Promise<void>;
-  preventScreenRecordWithImage: (image: NodeRequire) => Promise<void>;
+  preventScreenRecordWithImage: (
+    image: ImageResolvedAssetSource,
+    backgroundColor?: `#${string}`,
+    contentMode?: number
+  ) => Promise<void>;
   allowAppSwitcher: () => Promise<void>;
   preventAppSwitcher: () => Promise<void>;
   preventAppSwitcherWithText: (
@@ -63,7 +84,11 @@ export interface CaptureProtectionIOSNativeModules {
     textColor?: `#${string}`,
     backgroundColor?: `#${string}`
   ) => Promise<void>;
-  preventAppSwitcherWithImage: (image: NodeRequire) => Promise<void>;
+  preventAppSwitcherWithImage: (
+    image: ImageResolvedAssetSource,
+    backgroundColor?: `#${string}`,
+    contentMode?: number
+  ) => Promise<void>;
   hasListener: () => Promise<boolean>;
   protectionStatus: () => Promise<CaptureProtectionModuleStatus>;
   isScreenRecording: () => Promise<boolean | undefined>;


### PR DESCRIPTION
fixed #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the background color and image content mode when using image-based screen recording and app switcher protections on iOS.
  - Introduced a new set of content mode options to control how images are displayed.

- **Chores**
  - Updated the package version to 2.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->