### PR TITLE
fix: contentMode is not require

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-capture-protection",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "🛡️ A React Native library to prevent and detect for screen capture, screenshots and app switcher for enhanced security. Fully compatible with both Expo and CLI.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -8,6 +8,7 @@ import {
   CaptureProtectionAndroidNativeModules,
   CaptureProtectionFunction,
   CaptureProtectionIOSNativeModules,
+  ContentMode,
 } from './type';
 
 const CaptureProtectionModule = NativeModules?.CaptureProtection ?? {};
@@ -80,8 +81,8 @@ const prevent: CaptureProtectionFunction['prevent'] = async (option) => {
         if ('image' in appSwitcher) {
           await CaptureProtectionIOSModule?.preventAppSwitcherWithImage?.(
             Image.resolveAssetSource(appSwitcher.image as unknown as number),
-            appSwitcher?.backgroundColor,
-            appSwitcher?.contentMode
+            appSwitcher?.backgroundColor ?? "#ffffff",
+            appSwitcher?.contentMode ?? ContentMode.scaleAspectFit
           );
         } else {
           await CaptureProtectionIOSModule?.preventAppSwitcherWithText?.(
@@ -100,8 +101,8 @@ const prevent: CaptureProtectionFunction['prevent'] = async (option) => {
         if ('image' in record) {
           await CaptureProtectionIOSModule?.preventScreenRecordWithImage?.(
             Image.resolveAssetSource(record.image as unknown as number),
-            record?.backgroundColor,
-            record?.contentMode
+            record?.backgroundColor ?? "#ffffff",
+            record?.contentMode?? ContentMode.scaleAspectFit
           );
         } else {
           await CaptureProtectionIOSModule?.preventScreenRecordWithText?.(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured default values are applied for background color and content mode when preventing app switcher and screen recording on iOS, improving reliability.

- **Chores**
  - Updated package version to 2.0.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->