### PR TITLE
docs: add missing pod install step for IOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ npx expo install react-native-capture-protection
 Android 13 and Below: Enable Storage Permissions
 To detect screenshots on Android versions below 14, add the following
 
+### 🔧 iOS Setup
+
+If you're developing for iOS, don't forget to install CocoaPods dependencies after installing the package.
+
+```sh
+cd ios && pod install
+```
+
 ### **React Native CLI**
 
 add to `android/app/build.gradle`


### PR DESCRIPTION
### Summary

This PR adds a missing instruction to the README for iOS users.

After installing the library, iOS users must run `cd ios && pod install` to ensure the native code is correctly linked. Without this step, the capture protection features will not work on iOS, which may confuse new users.

Adding this line improves onboarding and prevents unnecessary debugging issues.

### Changes

- Added a new `🔧 iOS Setup` section in the Installation guide
- Alternatively added an inline comment next to `⚙️ Android Configuration (Required)` command

### Screenshot (optional)

Not applicable – documentation change only.

---

Let me know if you'd prefer this change in a different section or format!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for iOS developers to run pod install after package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->