### PR TITLE
fix: remove READ_MEDIA_IMAGES permission to comply with Google Play policies

### DIFF
--- a/android/src/fullMediaCapture/AndroidManifest.xml
+++ b/android/src/fullMediaCapture/AndroidManifest.xml
@@ -2,7 +2,4 @@
     <!-- Android 13 only support -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
-
-    <!-- else -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33" android:maxSdkVersion="34" />
 </manifest>


### PR DESCRIPTION
Removed the `READ_MEDIA_IMAGES` permission from `AndroidManifest.xml` so the app is not rejected during Google Play review.

Fixes #110. As mentioned in the issue comments, seems that the permission is not in use. Even with the changes introduced in version 2.3.3, the app was still rejected by Google Play.

I wasn’t able to run the example app due to Android build issues (specifically with `react-native-screens`), but I tested the change directly in my own app and, after removing this permission, the build was approved for the production track.

Regarding Android 13, everything continued to work after the change. I tested it on the emulator using the command:

`adb shell input keyevent 120`

<img width="948" height="931" alt="Screenshot_1763498869" src="https://github.com/user-attachments/assets/5bbef323-b284-4fff-bf83-2e246fe44590" />

If there’s anything else that needs to be adjusted, I’m happy to update the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified app storage permissions to use a unified approach for accessing media files across all supported Android versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->