### PR TITLE
Clarify different dimensions in README.md for Android below 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd ios && pod install
 ## ⚙️ Android Configuration (Required)
 
 By default, it supports capture prevention, capture permission, and capture detection on Android 14 and above.
-If you want capture detection(not prevent, only listener) support for versions below 14 (Android 10–13), please refer to the [Support Below Android 14, Capture Detection (Optional)](#support-below-android-14-capture-detection-optional) below.
+On Android versions below 14 (Android 10-13), capture prevention and capture permission are supported by default; if you want capture detection support too, please refer to the [Capture Detection Before Android 14 (Optional)](#capture-detection-before-android-14-optional) below.
 
 ### **React Native CLI**
 
@@ -93,10 +93,9 @@ add to `app.json`
 }
 ```
 
-## Support Below Android 14, Capture Detection (Optional)
+## Capture Detection Before Android 14 (Optional)
 
-On Android versions below 14, it detects screen captures using the sensitive READ_MEDIA_IMAGES permission.
-If you want detection to work on Android versions below 14, please configure the settings as follows.
+On Android versions below 14 (Android 10-13), capture prevention and capture permission are supported by default and require no more steps. However, if you want capture detection to work on Android versions below 14, please configure the settings as follows (it detects screen captures using the sensitive READ_MEDIA_IMAGES permission):
 
 ### Google Play Store Policy (READ_MEDIA_IMAGES)
 


### PR DESCRIPTION
I was confused by the explanation of the different dimensions / flavors for Android in the README.md, and had to read some discussions in ithe isues to understand that the optional steps for Android only added Capture Detection. To prevent other readers from having the same confusion, I propose these changes to the README.md to clarify the differences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android configuration guidance to clarify that capture prevention and permission are supported by default on Android 10–13.
  * Clarified that capture detection for older Android versions is optional.
  * Improved documentation cross-references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->